### PR TITLE
Add handler to query SSH service status

### DIFF
--- a/ovos_PHAL_plugin_system/__init__.py
+++ b/ovos_PHAL_plugin_system/__init__.py
@@ -13,8 +13,9 @@ from ovos_config.locations import OLD_USER_CONFIG, USER_CONFIG, WEB_CONFIG_CACHE
 from ovos_config.meta import get_xdg_base
 from ovos_plugin_manager.phal import PHALPlugin
 from ovos_utils.gui import GUIInterface
-from ovos_utils.system import system_shutdown, system_reboot, ssh_enable, ssh_disable, ntp_sync, restart_service, \
-    is_process_running
+from ovos_utils.system import system_shutdown, system_reboot, ssh_enable,\
+    ssh_disable, ntp_sync, restart_service, is_process_running, \
+    check_service_active
 from ovos_utils.xdg_utils import xdg_state_home, xdg_cache_home, xdg_data_home
 from ovos_utils.log import LOG
 
@@ -250,11 +251,9 @@ class SystemEvents(PHALPlugin):
 
     def handle_ssh_status(self, message):
         """
-        Check SSH service status and
+        Check SSH service status and emit a response
         """
-        stat = subprocess.run(f"systemctl is-active --quiet {self.ssh_service}",
-                              shell=True).returncode
-        enabled = stat == 0
+        enabled = check_service_active(self.ssh_service)
         self.bus.emit(message.response(data={'enabled': enabled}))
 
     def shutdown(self):

--- a/ovos_PHAL_plugin_system/__init__.py
+++ b/ovos_PHAL_plugin_system/__init__.py
@@ -36,6 +36,7 @@ class SystemEvents(PHALPlugin):
         self.gui = GUIInterface(bus=self.bus, skill_id=self.name)
 
         self.bus.on("system.ntp.sync", self.handle_ntp_sync_request)
+        self.bus.on("system.ssh.status", self.handle_ssh_status)
         self.bus.on("system.ssh.enable", self.handle_ssh_enable_request)
         self.bus.on("system.ssh.disable", self.handle_ssh_disable_request)
         self.bus.on("system.reboot", self.handle_reboot_request)
@@ -46,6 +47,8 @@ class SystemEvents(PHALPlugin):
         self.bus.on("system.mycroft.service.restart",
                     self.handle_mycroft_restart_request)
         self.service_name = config.get("core_service") or "mycroft.service"
+        # In Debian, ssh stays active, but sshd is removed when ssh is disabled
+        self.ssh_service = config.get("ssh_service") or "sshd.service"
         self.use_root = config.get("sudo", True)
 
         self.factory_reset_plugs = []
@@ -244,6 +247,15 @@ class SystemEvents(PHALPlugin):
             page = join(dirname(__file__), "ui", "Restart.qml")
             self.gui.show_page(page, override_animations=True, override_idle=True)
         restart_service(self.service_name, sudo=self.use_root)
+
+    def handle_ssh_status(self, message):
+        """
+        Check SSH service status and
+        """
+        stat = subprocess.run(f"systemctl is-active --quiet {self.ssh_service}",
+                              shell=True).returncode
+        enabled = stat == 0
+        self.bus.emit(message.response(data={'enabled': enabled}))
 
     def shutdown(self):
         self.bus.remove("system.ntp.sync", self.handle_ntp_sync_request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-plugin-manager~=0.0.1
-ovos-utils>=0.0.27a1
-ovos_config>=0.0.5a4
+ovos-utils~=0.0, >=0.0.30
+ovos_config~=0.0, >=0.0.5


### PR DESCRIPTION
Adds a messagebus handler to check if SSH is currently enabled or not. This can be used for the settings screen to show current SSH status and/or only display "enable" when the service is disabled and vice versa