### PR TITLE
Fix reference to SystemEvents class

### DIFF
--- a/ovos_PHAL_plugin_system/__init__.py
+++ b/ovos_PHAL_plugin_system/__init__.py
@@ -341,5 +341,5 @@ class SystemEventsAdminValidator(AdminValidator, SystemEventsValidator):
         LOG.info("ovos-PHAL-plugin-system running as root")
         return True
 
-class SystemEventsAdminPlugin(AdminPlugin, SystemEventsPlugin):
+class SystemEventsAdminPlugin(AdminPlugin, SystemEvents):
     validator = SystemEventsAdminValidator


### PR DESCRIPTION
In a recent commit for #21 SystemEvents was being referred to as SystemEventsPlugin, which broke ovos-PHAL-plugin-system.
This fix unbreaks it.