### PR TITLE
Resolve power permissions issues

### DIFF
--- a/ovos_PHAL_plugin_system/__init__.py
+++ b/ovos_PHAL_plugin_system/__init__.py
@@ -86,8 +86,8 @@ class SystemEventsPlugin(PHALPlugin):
         return external_requested or False
 
     @property
-    def sudo_power(self) -> bool:
-        return self.config.get("use_sudo_for_power") is False
+    def use_sudo_for_power(self) -> bool:
+        return self.config.get("use_sudo_for_power", True)
 
     def handle_reset_register(self, message):
         if not message.data.get("skill_id"):
@@ -235,7 +235,7 @@ class SystemEventsPlugin(PHALPlugin):
             subprocess.call(script, shell=True)
         else:
             command = "systemctl reboot -i"
-            if self.sudo_power:
+            if self.use_sudo_for_power:
                 command = f"sudo {command}"
             subprocess.call(command, shell=True)
 
@@ -253,7 +253,7 @@ class SystemEventsPlugin(PHALPlugin):
             subprocess.call(script, shell=True)
         else:
             command = "systemctl poweroff -i"
-            if self.sudo_power:
+            if self.use_sudo_for_power:
                 command = f"sudo {command}"
             subprocess.call(command, shell=True)
 

--- a/ovos_PHAL_plugin_system/__init__.py
+++ b/ovos_PHAL_plugin_system/__init__.py
@@ -85,6 +85,10 @@ class SystemEventsPlugin(PHALPlugin):
             return True
         return external_requested or False
 
+    @property
+    def sudo_power(self) -> bool:
+        return self.config.get("use_sudo_for_power") is False
+
     def handle_reset_register(self, message):
         if not message.data.get("skill_id"):
             LOG.warning(f"Got registration request without a `skill_id`: "
@@ -230,7 +234,10 @@ class SystemEventsPlugin(PHALPlugin):
         if script and os.path.isfile(script):
             subprocess.call(script, shell=True)
         else:
-            subprocess.call("systemctl reboot -i", shell=True)
+            command = "systemctl reboot -i"
+            if self.sudo_power:
+                command = f"sudo {command}"
+            subprocess.call(command, shell=True)
 
     def handle_shutdown_request(self, message):
         """
@@ -245,7 +252,10 @@ class SystemEventsPlugin(PHALPlugin):
         if script and os.path.isfile(script):
             subprocess.call(script, shell=True)
         else:
-            subprocess.call("systemctl poweroff -i", shell=True)
+            command = "systemctl poweroff -i"
+            if self.sudo_power:
+                command = f"sudo {command}"
+            subprocess.call(command, shell=True)
 
     def handle_configure_language_request(self, message):
         language_code = message.data.get('language_code', "en_US")


### PR DESCRIPTION
Add configuration option to use `sudo` with power commands (default `True` for backwards-compat)
Reverts behavior change introduced in #21 
Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `sudo_power` to enhance control over power-related commands.
	- Added a configuration-based property `use_sudo_for_power` to manage `sudo` usage for power operations.

- **Bug Fixes**
	- Improved command execution for system power operations by ensuring correct `sudo` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->