### PR TITLE
feat: status events

### DIFF
--- a/ovos_PHAL_plugin_system/__init__.py
+++ b/ovos_PHAL_plugin_system/__init__.py
@@ -88,7 +88,7 @@ class SystemEventsPlugin(PHALPlugin):
             return True
         return external_requested or False
 
-    def handle_reset_register(self, message):
+    def handle_reset_register(self, message: Message):
         if not message.data.get("skill_id"):
             LOG.warning(f"Got registration request without a `skill_id`: "
                         f"{message.data}")
@@ -102,7 +102,7 @@ class SystemEventsPlugin(PHALPlugin):
         if sid not in self.factory_reset_plugs:
             self.factory_reset_plugs.append(sid)
 
-    def handle_factory_reset_request(self, message):
+    def handle_factory_reset_request(self, message: Message):
         LOG.debug(f'Factory reset request: {message.data}')
         self.bus.emit(message.forward("system.factory.reset.start"))
         self.bus.emit(message.forward("system.factory.reset.ping"))
@@ -194,31 +194,31 @@ class SystemEventsPlugin(PHALPlugin):
         if reboot:
             self.bus.emit(message.forward("system.reboot"))
 
-    def handle_ssh_enable_request(self, message):
+    def handle_ssh_enable_request(self, message: Message):
         subprocess.call(f"systemctl enable {self.ssh_service}", shell=True)
         subprocess.call(f"systemctl start {self.ssh_service}", shell=True)
         self.bus.emit(message.forward("system.ssh.enabled", message.data))
 
-    def handle_ssh_enabled(self, message):
+    def handle_ssh_enabled(self, message: Message):
         # ovos-shell does not want to display
         if message.data.get("display", True):
             self.gui["status"] = "Enabled"
             self.gui["label"] = "SSH Enabled"
             self.gui.show_page("Status")
 
-    def handle_ssh_disable_request(self, message):
+    def handle_ssh_disable_request(self, message: Message):
         subprocess.call(f"systemctl stop {self.ssh_service}", shell=True)
         subprocess.call(f"systemctl disable {self.ssh_service}", shell=True)
         self.bus.emit(message.forward("system.ssh.disabled", message.data))
 
-    def handle_ssh_disabled(self, message):
+    def handle_ssh_disabled(self, message: Message):
         # ovos-shell does not want to display
         if message.data.get("display", True):
             self.gui["status"] = "Disabled"
             self.gui["label"] = "SSH Disabled"
             self.gui.show_page("Status")
 
-    def handle_rebooting(self, message):
+    def handle_rebooting(self, message: Message):
         """
         reboot has started
         """
@@ -238,7 +238,7 @@ class SystemEventsPlugin(PHALPlugin):
         else:
             subprocess.call("systemctl reboot -i", shell=True)
 
-    def handle_shutting_down(self, message):
+    def handle_shutting_down(self, message: Message):
         """
         shutdown has started
         """
@@ -246,7 +246,7 @@ class SystemEventsPlugin(PHALPlugin):
             self.gui.show_page("Shutdown", override_animations=True,
                                override_idle=True)
 
-    def handle_shutdown_request(self, message):
+    def handle_shutdown_request(self, message: Message):
         """
         Turn the system completely off (with no option to inhibit it)
         """
@@ -258,7 +258,7 @@ class SystemEventsPlugin(PHALPlugin):
         else:
             subprocess.call("systemctl poweroff -i", shell=True)
 
-    def handle_configure_language_request(self, message):
+    def handle_configure_language_request(self, message: Message):
         language_code = message.data.get('language_code', "en_US")
         with open(f"{os.environ['HOME']}/.bash_profile",
                   "w") as bash_profile_file:
@@ -279,12 +279,12 @@ class SystemEventsPlugin(PHALPlugin):
         self.bus.emit(Message('system.configure.language.complete',
                               {"lang": language_code}))
 
-    def handle_mycroft_restarting(self, message):
+    def handle_mycroft_restarting(self, message: Message):
         if message.data.get("display", True):
             self.gui.show_page("Restart", override_animations=True,
                                override_idle=True)
 
-    def handle_mycroft_restart_request(self, message):
+    def handle_mycroft_restart_request(self, message: Message):
         service = self.core_service_name
         self.bus.emit(message.forward("system.mycroft.service.restart.start", message.data))
         # TODO - clean up this mess
@@ -297,7 +297,7 @@ class SystemEventsPlugin(PHALPlugin):
                 LOG.error("No mycroft or ovos service installed")
                 return False
 
-    def handle_ssh_status(self, message):
+    def handle_ssh_status(self, message: Message):
         """
         Check SSH service status and emit a response
         """
@@ -317,7 +317,7 @@ class SystemEventsPlugin(PHALPlugin):
         self.bus.remove("system.factory.reset.register", self.handle_reset_register)
         self.bus.remove("system.configure.language", self.handle_configure_language_request)
         self.bus.remove("system.mycroft.service.restart", self.handle_mycroft_restart_request)
-        self.bus.remove("system.mycroft.service.restarting", self.handle_mycroft_restarting)
+        self.bus.remove("system.mycroft.service.restart.start", self.handle_mycroft_restarting)
         super().shutdown()
 
 


### PR DESCRIPTION
split feedback events to allow GUI integration via systemdhooks

similar to what we do for clock sync in raspOVOS https://github.com/TigreGotico/raspOVOS/commit/3ab5f44a189832bf4b61acfcfadabea352092f9e#diff-390ab68cb47cd597ab61ab48741f9d35ce7a7d514a4a40014df1222d402bead8R8

systemd hooks overview by chatgpt:
_____________

### **1. Scripts Before Reboot/Shutdown**
To run a script before a system reboot or shutdown:

#### **Create a Systemd Service for Shutdown Hooks**
1. Create a service file, e.g., `/etc/systemd/system/before-shutdown.service`:
   ```ini
   [Unit]
   Description=Run script before shutdown/reboot
   DefaultDependencies=no
   Before=halt.target reboot.target shutdown.target

   [Service]
   Type=oneshot
   ExecStart=/path/to/your/script.sh

   [Install]
   WantedBy=halt.target reboot.target shutdown.target
   ```

2. Reload systemd and enable the service:
   ```bash
   systemctl daemon-reload
   systemctl enable before-shutdown.service
   ```

#### **How It Works**
- **`Before=halt.target reboot.target shutdown.target`** ensures the script runs before these targets are reached.
- **`ExecStart`** specifies the script or command to run.

---

### **2. Scripts Before SSH Enable/Disable**
To run a script when the SSH service is enabled or disabled:

#### **Use Systemd Service Drop-Ins**
1. Create a drop-in file for `sshd.service`:
   ```bash
   mkdir -p /etc/systemd/system/ssh.service.d
   nano /etc/systemd/system/ssh.service.d/before-ssh-change.conf
   ```

2. Add the following configuration:
   ```ini
   [Service]
   ExecStartPre=/path/to/your/script-before-enable.sh
   ExecStopPost=/path/to/your/script-before-disable.sh
   ```

3. Reload systemd:
   ```bash
   systemctl daemon-reload
   ```

#### **How It Works**
- **`ExecStartPre`** runs before SSH starts.
- **`ExecStopPost`** runs after SSH stops.

---
